### PR TITLE
[Content Review] Corrige ponto-e-virgula errado no index

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,5 +6,5 @@ ReactDOM.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-  document.getElementById('root');
+  document.getElementById('root')
 );


### PR DESCRIPTION
A linha 9 estava dentro da chamada do `ReactDOM.render`, então não precisa de ponto-e-vírgula no final. Este token causava um erro na renderização.